### PR TITLE
format_ocsp_request: fix double encoding of the nonce

### DIFF
--- a/pyhanko_certvalidator/fetchers/common_utils.py
+++ b/pyhanko_certvalidator/fetchers/common_utils.py
@@ -132,12 +132,13 @@ def format_ocsp_request(cert: x509.Certificate, issuer: x509.Certificate,
     })
 
     if request_nonces:
-        nonce_extension = ocsp.TBSRequestExtension({
-            'extn_id': 'nonce',
-            'critical': False,
-            'extn_value': core.OctetString(
-                core.OctetString(os.urandom(16)).dump())
-        })
+        nonce_extension = ocsp.TBSRequestExtension(
+            {
+                'extn_id': 'nonce',
+                'critical': False,
+                'extn_value': core.OctetString(os.urandom(16)),
+            }
+        )
         tbs_request['request_extensions'] = ocsp.TBSRequestExtensions(
             [nonce_extension]
         )


### PR DESCRIPTION
The nonce should not be in 2 `core.OctetString`. Otherwise, when comparing the nonce received from the OCSP server, they don't match:
```
pyhanko_certvalidator.errors.OCSPValidationError: Unable to verify OCSP response since the request b'\x04\x10\xc3\xf9\x98\xaf\xe6\xd7\xf8v\xdfQ\xae\xac\x80B\x00!' and response b'\xc3\xf9\x98\xaf\xe6\xd7\xf8v\xdfQ\xae\xac\x80B\x00!' nonces do not match
```

Note the "Request nonce" starts with `\x04\x10` , that are not present in the "Response nonce".

# Reproduce issue
Download [facture-signed.pdf](https://github.com/MatthiasValvekens/certvalidator/files/10245499/facture-signed.pdf)


```console
cat > universign.pem <<EOF
-----BEGIN CERTIFICATE-----
MIIDuTCCAqGgAwIBAgIRAMMuCL31l3GyxK1mYwBZV/QwDQYJKoZIhvcNAQELBQAw
djELMAkGA1UEBhMCRlIxIDAeBgNVBAoTF0NyeXB0b2xvZyBJbnRlcm5hdGlvbmFs
MRwwGgYDVQQLExMwMDAyIDQzOTEyOTE2NDAwMDI2MScwJQYDVQQDEx5Vbml2ZXJz
aWduIFByaW1hcnkgQ0EgaGFyZHdhcmUwHhcNMTIwNTI5MTY1ODA3WhcNNDIwNTI5
MTY1ODA3WjB2MQswCQYDVQQGEwJGUjEgMB4GA1UEChMXQ3J5cHRvbG9nIEludGVy
bmF0aW9uYWwxHDAaBgNVBAsTEzAwMDIgNDM5MTI5MTY0MDAwMjYxJzAlBgNVBAMT
HlVuaXZlcnNpZ24gUHJpbWFyeSBDQSBoYXJkd2FyZTCCASIwDQYJKoZIhvcNAQEB
BQADggEPADCCAQoCggEBANmadE1N1cZBcDXE229NXXGngVJgy8DHoB3vVT2k16NH
HI9AtynXWo+xtiaSEi3IU6uoT85iPv+8IXb7pc7Kws7usrxoSkQKauqD10JGezoz
wU26+MIS96XZnWtxLieW7L7ibMnRyrH8eCQXA1VZox/QX5tM+fCL2cPLWbzDlVoh
9Kkg7OmIMPteTb6G5mTTBUzon7oAlEi3NRxpqsSMi2XMqYnqpP6w2hX/Yyjw3c+r
ZbjpFyxCpPxC1EvtkTP2znfsszmLwgvwO1wF47fJuhts4FgIZmTfAOKrVLzW7wC3
JW58/gUQXskc1i51TueF87X/2G4Wq4rXnz5Dn0k+Vb0CAwEAAaNCMEAwDwYDVR0T
AQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFE3Z/Kgtx8hapK1f
Sa5opNyeihIiMA0GCSqGSIb3DQEBCwUAA4IBAQAww+NfjmXYX/dQ6l6woSclAhPB
ZIGsfQ3mRTAsKsrvaEZvjhr+kM+btAVzG6UbDIRrp4JmeZId/teMYKo72hrT68x6
ZOkyFfIsv1oD0TGjEFYbX8JRfFd0xRm6vLJZfP6JdRIOH5vHsbid1P7Q6DbWO2c7
orwAM5PYQpnmf0dXvZ8DcxMajxtoSWGVw/gZRKQLm0x1Y3Hy6laHlzr6HBrPX5oV
L8AGGCythlO4SjO8c6nCa+gD6khN2PfC09NnoM6hma2xMtyiuv2yxpX9qCdQUJsP
oMYrphXqLU9uos/nNY4w+h0LSEBC3BOa6jH6sZZzoPuQXJR+CLgJaJ9te3gs
-----END CERTIFICATE-----
EOF

pyhanko --verbose sign validate --trust universign-root.pem   --pretty-print  ~/Downloads/facture-signed.pdf
```

## Expected
"Signature is valid"

## Got
```
pyhanko_certvalidator.errors.OCSPValidationError: Unable to verify OCSP response since the request b'\x04\x10\xc3\xf9\x98\xaf\xe6\xd7\xf8v\xdfQ\xae\xac\x80B\x00!' and response b'\xc3\xf9\x98\xaf\xe6\xd7\xf8v\xdfQ\xae\xac\x80B\x00!' nonces do not match
```
